### PR TITLE
Removed the Audio from the Database, and fixed some issues

### DIFF
--- a/script.sql
+++ b/script.sql
@@ -45,7 +45,7 @@ CREATE TABLE accelgyro_data
 
 	temperature     REAL,
 
-	PRIMARY KEY (accelerometer_id),
+	PRIMARY KEY (accelgyro_id),
 
-	FOREIGN KEY (accelerometer_id) REFERENCES sensor_data(accelerometer_id)
+	FOREIGN KEY (accelgyro_id) REFERENCES sensor_data(accelgyro_id)
 );


### PR DESCRIPTION
The audio being removed from the database has been done due to the many conflicting issues made during the discussion on the topic of recording the audio device. The removal of the microphone will help with reasoning on the database.

There also exists some other fixes, whether is be syntax compile errors or minor formatting issues.